### PR TITLE
Remote debugging support

### DIFF
--- a/tomcat-app/7.0/Dockerfile
+++ b/tomcat-app/7.0/Dockerfile
@@ -33,6 +33,8 @@ ADD app/init /usr/local/sbin/app-init
 RUN chmod 755 /usr/local/sbin/app-init
 ADD app/mvn /usr/local/bin/mvn
 RUN chmod 755 /usr/local/bin/mvn
+ADD app/tomcat-jpda /usr/local/sbin/tomcat-jpda
+RUN chmod 755 /usr/local/sbin/tomcat-jpda
 
 # System
 RUN dpkg-reconfigure -f noninteractive locales

--- a/tomcat-app/7.0/app/tomcat-jpda
+++ b/tomcat-app/7.0/app/tomcat-jpda
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ "x$CATALINA_OPTS" = "x" ]; then
+    CATALINA_OPTS="-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n" /usr/local/tomcat/bin/catalina.sh run
+else
+    CATALINA_OPTS="$CATALINA_OPTS -agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n" /usr/local/tomcat/bin/catalina.sh run
+fi

--- a/tomcat-app/7.0/supervisor/supervisord.conf
+++ b/tomcat-app/7.0/supervisor/supervisord.conf
@@ -4,6 +4,11 @@ nodaemon=true
 [program:tomcat]
 command=/usr/local/tomcat/bin/catalina.sh run
 
+[program:tomcat-jpda]
+command=/usr/local/sbin/tomcat-jpda
+autostart=false
+stopasgroup=true
+
 [program:app-init]
 command=/usr/local/sbin/app-init
 autorestart=false


### PR DESCRIPTION
This PR adds remote debugging support by the `tomcat-jpda` program. `tomcat-jpda` is not started by default, but it can be started manually as the following:

```console
# supervisorctl stop tomcat
# supervisorctl start tomcat-jpda
```