### PR TITLE
Always update before installation

### DIFF
--- a/symfony-app/php53/Dockerfile
+++ b/symfony-app/php53/Dockerfile
@@ -5,6 +5,7 @@
 FROM phpmentors/php-app:php53
 MAINTAINER KUBO Atsuhiro <kubo@iteman.jp>
 
+RUN apt-get update
 RUN apt-get install -y libfile-slurp-perl php5-sqlite
 
 # Apache2

--- a/symfony-app/php55/Dockerfile
+++ b/symfony-app/php55/Dockerfile
@@ -5,6 +5,7 @@
 FROM phpmentors/php-app:php55
 MAINTAINER KUBO Atsuhiro <kubo@iteman.jp>
 
+RUN apt-get update
 RUN apt-get install -y libfile-slurp-perl php5-sqlite
 
 # Apache2


### PR DESCRIPTION
Always run `apt-get update` in order to ensure up-to-date URLs.
Fixes errors when cache from parent is too old.