### PR TITLE
Fixing curl error

### DIFF
--- a/tomcat-app/7.0/Dockerfile
+++ b/tomcat-app/7.0/Dockerfile
@@ -20,13 +20,15 @@ RUN apt-get install -y openjdk-7-jdk
 RUN mkdir -p /var/log/supervisor
 ADD supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
+# Maven
+ENV MAVEN_VERSION 3.3.9
+ENV MAVEN_HOME /usr/share/maven
+RUN curl -fsSLk https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar xzf - -C /usr/share && mv /usr/share/apache-maven-$MAVEN_VERSION $MAVEN_HOME
+
 # Tomcat
 RUN sed -i "s/\(<tomcat-users>\)/\\1\\n  <role rolename=\"manager-gui\"\/>\\n  <role rolename=\"manager-script\"\/>\\n  <user username=\"admin\" password=\"\" roles=\"manager-gui,manager-script\"\/>/" /usr/local/tomcat/conf/tomcat-users.xml
 
 # Tomcat application
-ENV MAVEN_VERSION 3.3.9
-ENV MAVEN_HOME /usr/share/maven
-RUN curl -fsSLk https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar xzf - -C /usr/share && mv /usr/share/apache-maven-$MAVEN_VERSION $MAVEN_HOME
 ADD app/init /usr/local/sbin/app-init
 RUN chmod 755 /usr/local/sbin/app-init
 ADD app/mvn /usr/local/bin/mvn

--- a/tomcat-app/7.0/Dockerfile
+++ b/tomcat-app/7.0/Dockerfile
@@ -26,7 +26,7 @@ RUN sed -i "s/\(<tomcat-users>\)/\\1\\n  <role rolename=\"manager-gui\"\/>\\n  <
 # Tomcat application
 ENV MAVEN_VERSION 3.3.9
 ENV MAVEN_HOME /usr/share/maven
-RUN curl -fsSL https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar xzf - -C /usr/share && mv /usr/share/apache-maven-$MAVEN_VERSION $MAVEN_HOME
+RUN curl -fsSLk https://archive.apache.org/dist/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz | tar xzf - -C /usr/share && mv /usr/share/apache-maven-$MAVEN_VERSION $MAVEN_HOME
 ADD app/init /usr/local/sbin/app-init
 RUN chmod 755 /usr/local/sbin/app-init
 ADD app/mvn /usr/local/bin/mvn


### PR DESCRIPTION
This will fix `SSL certificate problem` error on building an image as follows:

```console
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: http://curl.haxx.se/docs/sslcerts.html

curl performs SSL certificate verification by default, using a "bundle"
 of Certificate Authority (CA) public keys (CA certs). If the default
 bundle file isn't adequate, you can specify an alternate file
 using the --cacert option.
If this HTTPS server uses a certificate signed by a CA represented in
 the bundle, the certificate verification probably failed due to a
 problem with the certificate (it might be expired, or the name might
 not match the domain name in the URL).
If you'd like to turn off curl's verification of the certificate, use
 the -k (or --insecure) option.
```